### PR TITLE
fix: Use uv sync without --frozen (uv.lock is gitignored)

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -25,7 +25,7 @@ jobs:
           version: "latest"
 
       - name: Install Python dependencies
-        run: uv sync --frozen
+        run: uv sync
 
       - name: Install Playwright browsers
         run: uv run playwright install chromium --with-deps


### PR DESCRIPTION
## Summary

- Reverts `uv sync --frozen` to `uv sync` in `refresh.yml`
- `uv.lock` is listed in `.gitignore`, so it won't be present in CI checkouts, causing `--frozen` to fail

## Context

- Issue #13 tracks the broader fix: remove `uv.lock` from `.gitignore` and commit it
- Once #13 is resolved, `--frozen` can be re-added for reproducible CI builds
- Flagged by python-expert during cross-PR review

## Test plan

- [ ] Verify `refresh.yml` workflow succeeds with `uv sync` (no lock file needed)

Generated with [Claude Code](https://claude.com/claude-code)