### PR TITLE
fix: Replace innerHTML with DOM construction in showError()

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -231,14 +231,12 @@ function showEmptyState() {
 }
 
 function showError(msg) {
-  transcriptPanel.innerHTML =
-    '<div class="error-state"><p>' + escapeHTML(msg) + '</p></div>';
-}
-
-function escapeHTML(str) {
-  const el = document.createElement('span');
-  el.textContent = str;
-  return el.innerHTML;
+  const div = document.createElement('div');
+  div.className = 'error-state';
+  const p = document.createElement('p');
+  p.textContent = msg;
+  div.appendChild(p);
+  transcriptPanel.replaceChildren(div);
 }
 
 // ── Search (Issue #5) ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace `showError()`'s `innerHTML` + `escapeHTML()` pattern with `createElement`/`textContent`/`replaceChildren` for consistency with the rest of `app.js`
- Remove the now-unused `escapeHTML()` helper function

Flagged by pr-reviewer in PR #20 review.

## Test plan

- [x] `uv run pytest tests/test_ui.py -v` — all 13 tests pass
- [ ] Trigger an error state (e.g., bad manifest URL) and verify the error message renders correctly

Generated with [Claude Code](https://claude.com/claude-code)