### PR TITLE
fix(a11y): set aria-pressed on all date buttons (Issue #23)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -101,9 +101,7 @@ function renderDateList(meetings, activeDate, matchCounts) {
       btn.appendChild(badge);
     }
 
-    if (m.date === activeDate) {
-      btn.setAttribute('aria-pressed', 'true');
-    }
+    btn.setAttribute('aria-pressed', m.date === activeDate ? 'true' : 'false');
     btn.addEventListener('click', () => onDateClick(m.date));
     li.appendChild(btn);
     dateList.appendChild(li);


### PR DESCRIPTION
## Summary

- Set `aria-pressed` explicitly on every date button (both active and inactive) per WAI-ARIA toggle button semantics
- Replace the conditional `if`-block with an unconditional ternary: `btn.setAttribute('aria-pressed', m.date === activeDate ? 'true' : 'false')`

## Why

WAI-ARIA 1.2 requires that `aria-pressed` is always present on toggle buttons — not only when the button is pressed. Screen readers that enumerate a button group expect the attribute on every member so they can announce "1 of N selected" state correctly.

## Test plan

- [ ] Open the site, select a SIG
- [ ] Inspect DOM: every date `<button>` has `aria-pressed="true"` or `aria-pressed="false"`
- [ ] Navigate the list with a screen reader — state is announced correctly for all buttons

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)