### PR TITLE
ci: add concurrency controls, uv caching, and update action versions

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: "refresh"
+  cancel-in-progress: true
+
 jobs:
   refresh:
     runs-on: ubuntu-latest
@@ -23,6 +27,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Install Python dependencies
         run: uv sync --frozen

--- a/.github/workflows/summarize.yml
+++ b/.github/workflows/summarize.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: "summarize"
+  cancel-in-progress: true
+
 jobs:
   summarize:
     runs-on: ubuntu-latest
@@ -17,11 +21,12 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Install Python dependencies
         run: uv sync --frozen --group summarize


### PR DESCRIPTION
## Summary
- **Concurrency groups** added to `refresh.yml` and `summarize.yml` to prevent overlapping runs (e.g., a manual `workflow_dispatch` during a scheduled cron run)
- **uv cache** enabled via `enable-cache: true` in `setup-uv` for both workflows, reducing dependency install time on subsequent runs
- **Action versions bumped** in `summarize.yml` to match `refresh.yml`: `actions/checkout@v4` -> `@v6`, `astral-sh/setup-uv@v4` -> `@v7`

## Workflow audit notes
The `pages.yml` workflow was already well-configured (correct permissions, concurrency group, no uv usage). No changes needed there.

## Test plan
- [ ] Verify `refresh.yml` runs correctly on `workflow_dispatch`
- [ ] Verify `summarize.yml` runs correctly on `workflow_dispatch`
- [ ] Confirm concurrency cancellation works when triggering overlapping runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)