### PR TITLE
fix(ci): skip commit when no new summaries generated

### DIFF
--- a/.github/workflows/summarize.yml
+++ b/.github/workflows/summarize.yml
@@ -36,17 +36,17 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: uv run python generate_summaries.py
 
-      - name: Rebuild site (update manifest has_summary flags)
-        run: uv run python build_site.py
-
       - name: Commit changes if any
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/summaries/ docs/manifest.json
+          git add docs/summaries/
           if git diff --cached --quiet; then
             echo "No new summaries to commit — skipping."
           else
+            echo "New summaries detected — rebuilding manifest."
+            uv run python build_site.py
+            git add docs/manifest.json
             git commit -m "chore: generate meeting summaries $(date -u +%Y-%m-%d)"
             git push
           fi


### PR DESCRIPTION
## Summary
- **Fixes #35** — `summarize.yml` always created a commit because `build_site.py` rewrites `generated_at` with the current UTC timestamp, making `docs/manifest.json` always show as changed.
- Now we stage only `docs/summaries/` first and check `git diff --cached --quiet`. If no summaries changed, the workflow skips the commit entirely.
- `build_site.py` (and `docs/manifest.json` staging) only runs when new summaries actually exist.

## Test plan
- [ ] Trigger `summarize.yml` via `workflow_dispatch` with no new transcripts — verify no commit is created
- [ ] Add a new transcript, trigger `summarize.yml` — verify commit includes both summaries and updated manifest
- [ ] Verify YAML syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)