### PR TITLE
fix(ci): trigger Pages deploy after automated workflow runs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+  workflow_run:
+    workflows: ["Refresh Transcripts", "Generate Summaries"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -18,6 +21,9 @@ concurrency:
 
 jobs:
   deploy:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- **Fixes #38** — `GITHUB_TOKEN`-authenticated pushes from `refresh.yml` and `summarize.yml` do not trigger downstream `on: push` workflows (this is a GitHub limitation).
- Adds a `workflow_run` trigger to `pages.yml` that fires after `Refresh Transcripts` or `Generate Summaries` complete successfully.
- Retains existing `push` (for manual/PAT pushes) and `workflow_dispatch` triggers.
- Adds a job-level `if` condition to skip deployment when the upstream workflow failed.

## Test plan
- [ ] Trigger `refresh.yml` via `workflow_dispatch` — verify `pages.yml` fires afterward
- [ ] Trigger `summarize.yml` via `workflow_dispatch` — verify `pages.yml` fires afterward
- [ ] Push docs changes manually — verify `pages.yml` still fires via `on: push`
- [ ] Verify `pages.yml` does not deploy if upstream workflow fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)