### PR TITLE
fix: remove stale files from docs/ tree (Issue #36)

### DIFF
--- a/build_site.py
+++ b/build_site.py
@@ -22,9 +22,45 @@ SUMMARIES_DIR = DOCS_DIR / "summaries"
 MANIFEST_PATH = DOCS_DIR / "manifest.json"
 
 
+def _remove_stale_docs(
+    source_slugs: set[str],
+    source_files: set[tuple[str, str]],
+) -> None:
+    """Remove files/dirs under docs/transcripts/ and docs/summaries/ that
+    no longer have a corresponding source in transcripts/.
+
+    *source_slugs* is the set of SIG slugs found in transcripts/.
+    *source_files* is a set of (slug, filename) pairs for every valid transcript.
+    """
+    docs_transcripts = DOCS_DIR / "transcripts"
+    if docs_transcripts.is_dir():
+        for slug_dir in sorted(docs_transcripts.iterdir()):
+            if not slug_dir.is_dir():
+                continue
+            slug = slug_dir.name
+            if slug not in source_slugs:
+                shutil.rmtree(slug_dir)
+                print(f"  Removed stale docs/transcripts/{slug}/")
+                continue
+            for txt_file in sorted(slug_dir.glob("*.txt")):
+                if (slug, txt_file.name) not in source_files:
+                    txt_file.unlink()
+                    print(f"  Removed stale docs/transcripts/{slug}/{txt_file.name}")
+
+    if SUMMARIES_DIR.is_dir():
+        for slug_dir in sorted(SUMMARIES_DIR.iterdir()):
+            if not slug_dir.is_dir():
+                continue
+            if slug_dir.name not in source_slugs:
+                shutil.rmtree(slug_dir)
+                print(f"  Removed stale docs/summaries/{slug_dir.name}/")
+
+
 def build_manifest() -> dict:
     """Walk transcripts/ and build the manifest dict + copy files to docs/."""
     sigs: dict[str, dict] = {}
+    source_slugs: set[str] = set()
+    source_files: set[tuple[str, str]] = set()
 
     for txt_path in sorted(TRANSCRIPTS_SRC.glob("*/*.txt")):
         slug = txt_path.parent.name
@@ -32,6 +68,9 @@ def build_manifest() -> dict:
         if header is None:
             print(f"  WARNING: skipping {txt_path} (unparseable header)")
             continue
+
+        source_slugs.add(slug)
+        source_files.add((slug, txt_path.name))
 
         date_str = header["date"]
 
@@ -57,6 +96,8 @@ def build_manifest() -> dict:
                 "meetings": [],
             }
         sigs[slug]["meetings"].append(meeting_entry)
+
+    _remove_stale_docs(source_slugs, source_files)
 
     # Sort meetings within each SIG by date descending
     for sig_data in sigs.values():

--- a/tests/test_build_manifest.py
+++ b/tests/test_build_manifest.py
@@ -228,3 +228,91 @@ class TestBuildManifest:
         serialized = json.dumps(manifest, indent=2)
         roundtripped = json.loads(serialized)
         assert roundtripped["sigs"][0]["slug"] == "Go-SIG"
+
+
+class TestStaleFileRemoval:
+    def test_stale_transcript_file_removed(self, tmp_path: Path) -> None:
+        """A file in docs/transcripts/ with no source counterpart is removed."""
+        src = tmp_path / "transcripts"
+        docs = tmp_path / "docs"
+        _write_transcript(src, "Go-SIG", "2026-02-05.txt", SAMPLE_TRANSCRIPT)
+
+        # Pre-create a stale file in docs/transcripts/
+        stale_dir = docs / "transcripts" / "Go-SIG"
+        stale_dir.mkdir(parents=True)
+        stale_file = stale_dir / "2025-01-01.txt"
+        stale_file.write_text("stale content")
+
+        with patch("build_site.TRANSCRIPTS_SRC", src), \
+             patch("build_site.DOCS_DIR", docs), \
+             patch("build_site.SUMMARIES_DIR", docs / "summaries"):
+            build_manifest()
+
+        assert not stale_file.exists()
+        # The valid file should still be there
+        assert (docs / "transcripts" / "Go-SIG" / "2026-02-05.txt").exists()
+
+    def test_stale_sig_directory_removed(self, tmp_path: Path) -> None:
+        """An entire SIG directory in docs/transcripts/ is removed when no
+        source transcripts exist for that slug."""
+        src = tmp_path / "transcripts"
+        docs = tmp_path / "docs"
+        _write_transcript(src, "Go-SIG", "2026-02-05.txt", SAMPLE_TRANSCRIPT)
+
+        # Pre-create a stale SIG directory
+        stale_dir = docs / "transcripts" / "Old-SIG"
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "2025-01-01.txt").write_text("stale")
+
+        with patch("build_site.TRANSCRIPTS_SRC", src), \
+             patch("build_site.DOCS_DIR", docs), \
+             patch("build_site.SUMMARIES_DIR", docs / "summaries"):
+            build_manifest()
+
+        assert not stale_dir.exists()
+
+    def test_stale_summary_directory_removed(self, tmp_path: Path) -> None:
+        """An orphaned SIG directory in docs/summaries/ is removed when no
+        source transcripts exist for that slug."""
+        src = tmp_path / "transcripts"
+        docs = tmp_path / "docs"
+        _write_transcript(src, "Go-SIG", "2026-02-05.txt", SAMPLE_TRANSCRIPT)
+
+        # Pre-create a stale summary directory
+        stale_summary = docs / "summaries" / "Old-SIG"
+        stale_summary.mkdir(parents=True)
+        (stale_summary / "2025-01-01.md").write_text("stale summary")
+
+        with patch("build_site.TRANSCRIPTS_SRC", src), \
+             patch("build_site.DOCS_DIR", docs), \
+             patch("build_site.SUMMARIES_DIR", docs / "summaries"):
+            build_manifest()
+
+        assert not stale_summary.exists()
+
+    def test_no_stale_files_is_noop(self, tmp_path: Path) -> None:
+        """When docs/ mirrors source exactly, nothing is removed."""
+        src = tmp_path / "transcripts"
+        docs = tmp_path / "docs"
+        _write_transcript(src, "Go-SIG", "2026-02-05.txt", SAMPLE_TRANSCRIPT)
+
+        with patch("build_site.TRANSCRIPTS_SRC", src), \
+             patch("build_site.DOCS_DIR", docs), \
+             patch("build_site.SUMMARIES_DIR", docs / "summaries"):
+            build_manifest()
+
+        assert (docs / "transcripts" / "Go-SIG" / "2026-02-05.txt").exists()
+
+    def test_docs_transcripts_dir_missing_is_safe(self, tmp_path: Path) -> None:
+        """build_manifest works even when docs/transcripts/ doesn't exist yet."""
+        src = tmp_path / "transcripts"
+        docs = tmp_path / "docs"
+        _write_transcript(src, "Go-SIG", "2026-02-05.txt", SAMPLE_TRANSCRIPT)
+
+        # Don't pre-create docs/ at all
+        with patch("build_site.TRANSCRIPTS_SRC", src), \
+             patch("build_site.DOCS_DIR", docs), \
+             patch("build_site.SUMMARIES_DIR", docs / "summaries"):
+            manifest = build_manifest()
+
+        assert len(manifest["sigs"]) == 1


### PR DESCRIPTION
Fixes #36

## Summary
- `build_site.py` now tracks source transcript (slug, filename) pairs during manifest building
- New `_remove_stale_docs()` function runs after copying, removing:
  - Individual `.txt` files in `docs/transcripts/` that have no source counterpart
  - Entire SIG directories from `docs/transcripts/` when the slug no longer exists in source
  - Orphaned SIG directories from `docs/summaries/` for removed SIGs
- Added 5 new tests in `TestStaleFileRemoval` class covering stale file, stale directory, stale summary, no-op, and missing-docs edge cases

## Test plan
- [x] All 21 tests in `test_build_manifest.py` pass (16 existing + 5 new)
- [x] All 16 tests in `test_generate_summaries.py` still pass