### PR TITLE
fix: deterministic SIG display name from latest transcript (Issue #37)

### DIFF
--- a/build_site.py
+++ b/build_site.py
@@ -87,6 +87,7 @@ def build_manifest() -> dict:
             "date": date_str,
             "duration_minutes": header["duration_minutes"],
             "has_summary": has_summary,
+            "_sig_name": header["sig_name"],
         }
 
         if slug not in sigs:
@@ -99,9 +100,13 @@ def build_manifest() -> dict:
 
     _remove_stale_docs(source_slugs, source_files)
 
-    # Sort meetings within each SIG by date descending
+    # Sort meetings within each SIG by date descending, then use the
+    # latest meeting's SIG name as the canonical display name.
     for sig_data in sigs.values():
         sig_data["meetings"].sort(key=lambda m: m["date"], reverse=True)
+        sig_data["name"] = sig_data["meetings"][0]["_sig_name"]
+        for m in sig_data["meetings"]:
+            del m["_sig_name"]
 
     # Sort SIGs alphabetically by slug
     sorted_sigs = sorted(sigs.values(), key=lambda s: s["slug"])

--- a/tests/test_build_manifest.py
+++ b/tests/test_build_manifest.py
@@ -41,6 +41,16 @@ Source URL: https://zoom.us/rec/share/java123
 Jack 00:01 Hello!
 """
 
+SAMPLE_TRANSCRIPT_RENAMED = """\
+SIG: Go Instrumentation SIG
+Date: 2026-02-19
+Duration: 50 minutes
+Source URL: https://zoom.us/rec/share/ghi789
+============================================================
+
+Tyler 02:00 We renamed the SIG.
+"""
+
 
 def _write_transcript(base: Path, slug: str, filename: str, content: str) -> None:
     d = base / slug
@@ -212,6 +222,47 @@ class TestBuildManifest:
         durations = {m["date"]: m["duration_minutes"] for m in meetings}
         assert durations["2026-02-05"] == 33
         assert durations["2026-02-12"] == 45
+
+    def test_display_name_from_latest_transcript(self, tmp_path: Path) -> None:
+        """SIG display name should come from the latest-dated transcript,
+        not from alphabetical file order."""
+        src = tmp_path / "transcripts"
+        docs = tmp_path / "docs"
+        # Older transcript uses "Go SIG"
+        _write_transcript(src, "Go-SIG", "2026-02-05.txt", SAMPLE_TRANSCRIPT)
+        # Newer transcript uses "Go Instrumentation SIG" (renamed)
+        _write_transcript(src, "Go-SIG", "2026-02-19.txt", SAMPLE_TRANSCRIPT_RENAMED)
+
+        with patch("build_site.TRANSCRIPTS_SRC", src), \
+             patch("build_site.DOCS_DIR", docs), \
+             patch("build_site.SUMMARIES_DIR", docs / "summaries"):
+            manifest = build_manifest()
+
+        sig = manifest["sigs"][0]
+        assert sig["name"] == "Go Instrumentation SIG"
+
+    def test_display_name_stable_with_older_file_added(self, tmp_path: Path) -> None:
+        """Adding an older transcript should not change the display name."""
+        src = tmp_path / "transcripts"
+        docs = tmp_path / "docs"
+        # Only the newer transcript initially
+        _write_transcript(src, "Go-SIG", "2026-02-19.txt", SAMPLE_TRANSCRIPT_RENAMED)
+
+        with patch("build_site.TRANSCRIPTS_SRC", src), \
+             patch("build_site.DOCS_DIR", docs), \
+             patch("build_site.SUMMARIES_DIR", docs / "summaries"):
+            manifest = build_manifest()
+        assert manifest["sigs"][0]["name"] == "Go Instrumentation SIG"
+
+        # Now add an older transcript with a different name
+        _write_transcript(src, "Go-SIG", "2026-02-05.txt", SAMPLE_TRANSCRIPT)
+
+        with patch("build_site.TRANSCRIPTS_SRC", src), \
+             patch("build_site.DOCS_DIR", docs), \
+             patch("build_site.SUMMARIES_DIR", docs / "summaries"):
+            manifest = build_manifest()
+        # Display name should still be from the latest transcript
+        assert manifest["sigs"][0]["name"] == "Go Instrumentation SIG"
 
     def test_manifest_json_serializable(self, tmp_path: Path) -> None:
         src = tmp_path / "transcripts"


### PR DESCRIPTION
Fixes #37

## Summary
- SIG display name in the manifest was previously taken from the first transcript encountered (alphabetical file order), making it non-deterministic
- Now each meeting temporarily carries its header's SIG name; after sorting by date descending, the latest transcript's name becomes the canonical display name
- The temporary `_sig_name` key is cleaned up before the manifest is returned

## Test plan
- [x] New test: `test_display_name_from_latest_transcript` — verifies latest-dated name wins over alphabetically-first
- [x] New test: `test_display_name_stable_with_older_file_added` — verifies adding an older file doesn't change the name
- [x] All 18 tests in `test_build_manifest.py` pass (16 existing + 2 new)