### PR TITLE
fix(test): skip summary tests when openai is absent (Issue #39)

### DIFF
--- a/tests/test_generate_summaries.py
+++ b/tests/test_generate_summaries.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("openai")
+
 from generate_summaries import (
     MAX_TRANSCRIPT_CHARS,
     generate_summary,


### PR DESCRIPTION
Fixes #39

## Summary
- Added `pytest.importorskip("openai")` before importing from `generate_summaries` in `tests/test_generate_summaries.py`
- When `openai` is not installed (e.g., `make test` with `--group dev` only), the test module is gracefully skipped instead of erroring with `ModuleNotFoundError`
- When `openai` IS installed, all 16 tests still pass normally

## Test plan
- [x] `uv run --group dev pytest tests/test_generate_summaries.py -v` → 1 skipped (graceful)
- [x] `uv run --group dev --group summarize pytest tests/test_generate_summaries.py -v` → 16 passed