### PR TITLE
fix: defer OpenAI import so make test works without summarize group

### DIFF
--- a/generate_summaries.py
+++ b/generate_summaries.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
-
-from openai import OpenAI
+from typing import TYPE_CHECKING
 
 from scraper.transcript_io import SEPARATOR, parse_header
+
+if TYPE_CHECKING:
+    from openai import OpenAI
 
 ROOT = Path(__file__).parent
 DOCS_TRANSCRIPTS_DIR = ROOT / "docs" / "transcripts"
@@ -125,6 +127,8 @@ def main() -> None:
     if not api_key:
         print("ERROR: OPENAI_API_KEY environment variable is not set")
         raise SystemExit(1)
+
+    from openai import OpenAI  # noqa: PLC0415 — deferred to avoid import error in dev envs
 
     client = OpenAI(api_key=api_key)
     generated, skipped = process_transcripts(client)

--- a/tests/test_generate_summaries.py
+++ b/tests/test_generate_summaries.py
@@ -10,7 +10,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from generate_summaries import (
+pytest.importorskip("openai", reason="openai package not installed (install with --group summarize)")
+
+from generate_summaries import (  # noqa: E402
     MAX_TRANSCRIPT_CHARS,
     generate_summary,
     process_transcripts,


### PR DESCRIPTION
## Summary
- **Fixes #39** — `generate_summaries.py` had `from openai import OpenAI` at module level. Since `openai` is in the `[summarize]` dependency group (not `[dev]`), running `make test` in dev-only environments failed with `ModuleNotFoundError`.
- Moved the runtime import into `main()` where the client is actually constructed.
- Used `TYPE_CHECKING` guard for the `OpenAI` type hints in function signatures (with `from __future__ import annotations` already active, these are strings at runtime).
- Added `pytest.importorskip("openai")` in the test file as a safety net.

## Test plan
- [x] All 16 tests in `test_generate_summaries.py` pass (verified locally)
- [x] All 37 tests across both test files pass with no regressions
- [ ] Verify `make test` works in a fresh dev-only environment (no `--group summarize`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)