### PR TITLE
fix: defer OpenAI import and remove redundant importorskip (Issues #39, #51)

### DIFF
--- a/generate_summaries.py
+++ b/generate_summaries.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
-
-from openai import OpenAI
+from typing import TYPE_CHECKING
 
 from scraper.transcript_io import SEPARATOR, parse_header
+
+if TYPE_CHECKING:
+    from openai import OpenAI
 
 ROOT = Path(__file__).parent
 DOCS_TRANSCRIPTS_DIR = ROOT / "docs" / "transcripts"
@@ -125,6 +127,8 @@ def main() -> None:
     if not api_key:
         print("ERROR: OPENAI_API_KEY environment variable is not set")
         raise SystemExit(1)
+
+    from openai import OpenAI  # noqa: PLC0415 — deferred to avoid import error in dev envs
 
     client = OpenAI(api_key=api_key)
     generated, skipped = process_transcripts(client)

--- a/tests/test_generate_summaries.py
+++ b/tests/test_generate_summaries.py
@@ -10,8 +10,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytest.importorskip("openai")
-
 from generate_summaries import (
     MAX_TRANSCRIPT_CHARS,
     generate_summary,


### PR DESCRIPTION
## Summary
- **Fixes #39** — `generate_summaries.py` had `from openai import OpenAI` at module level. Since `openai` is in the `[summarize]` dependency group (not `[dev]`), `make test` failed with `ModuleNotFoundError` in dev-only environments.
- **Fixes #51** — `pytest.importorskip("openai")` was added as a workaround but silently skipped all 16 mocked tests in dev environments, dropping coverage.

**Both changes are atomic in this PR:**
1. `generate_summaries.py`: Move `from openai import OpenAI` into `main()` (deferred import), add `TYPE_CHECKING` guard for type hints (safe with `from __future__ import annotations`)
2. `tests/test_generate_summaries.py`: Remove `pytest.importorskip("openai")` — no longer needed with the deferred import, and harmful because it skipped all mocked tests

## Test plan
- [x] All 16 `test_generate_summaries.py` tests pass (not skipped) — verified locally
- [x] All 39 Python tests pass with no regressions
- [ ] Verify `make test` works in a fresh dev-only environment (no `--group summarize`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)