### PR TITLE
fix: prevent stale deletion of docs with malformed headers (Issue #50)

### DIFF
--- a/build_site.py
+++ b/build_site.py
@@ -30,7 +30,7 @@ def _remove_stale_docs(
     no longer have a corresponding source in transcripts/.
 
     *source_slugs* is the set of SIG slugs found in transcripts/.
-    *source_files* is a set of (slug, filename) pairs for every valid transcript.
+    *source_files* is a set of (slug, filename) pairs for every .txt file in transcripts/.
     """
     docs_transcripts = DOCS_DIR / "transcripts"
     if docs_transcripts.is_dir():
@@ -64,13 +64,13 @@ def build_manifest() -> dict:
 
     for txt_path in sorted(TRANSCRIPTS_SRC.glob("*/*.txt")):
         slug = txt_path.parent.name
+        source_slugs.add(slug)
+        source_files.add((slug, txt_path.name))
+
         header = parse_header(txt_path)
         if header is None:
             print(f"  WARNING: skipping {txt_path} (unparseable header)")
             continue
-
-        source_slugs.add(slug)
-        source_files.add((slug, txt_path.name))
 
         date_str = header["date"]
 

--- a/tests/test_build_manifest.py
+++ b/tests/test_build_manifest.py
@@ -367,3 +367,28 @@ class TestStaleFileRemoval:
             manifest = build_manifest()
 
         assert len(manifest["sigs"]) == 1
+
+    def test_malformed_header_does_not_delete_docs(self, tmp_path: Path) -> None:
+        """A source file with an unparseable header must not cause its
+        previously-published docs to be treated as stale and deleted."""
+        src = tmp_path / "transcripts"
+        docs = tmp_path / "docs"
+
+        # One valid transcript and one malformed transcript in the same SIG
+        _write_transcript(src, "Go-SIG", "2026-02-05.txt", SAMPLE_TRANSCRIPT)
+        _write_transcript(src, "Go-SIG", "2026-02-10.txt", "garbage header\n")
+
+        # Simulate a previous build that copied both files to docs/
+        dest = docs / "transcripts" / "Go-SIG"
+        dest.mkdir(parents=True)
+        (dest / "2026-02-05.txt").write_text(SAMPLE_TRANSCRIPT)
+        (dest / "2026-02-10.txt").write_text("garbage header\n")
+
+        with patch("build_site.TRANSCRIPTS_SRC", src), \
+             patch("build_site.DOCS_DIR", docs), \
+             patch("build_site.SUMMARIES_DIR", docs / "summaries"):
+            build_manifest()
+
+        # Neither file should be deleted — the malformed one still exists in source
+        assert (dest / "2026-02-05.txt").exists()
+        assert (dest / "2026-02-10.txt").exists()


### PR DESCRIPTION
Fixes #50

## Summary
- Moved `source_slugs.add(slug)` and `source_files.add((slug, txt_path.name))` **before** the `parse_header()` check in `build_manifest()`
- Previously, a transcript with a malformed header was never tracked in the source sets, so `_remove_stale_docs()` would incorrectly delete its previously-published docs
- Updated `_remove_stale_docs` docstring to reflect that it tracks all `.txt` files, not just valid ones
- Added `test_malformed_header_does_not_delete_docs` test: creates a valid + malformed transcript in the same SIG, pre-populates docs/, and verifies neither file is deleted

## Test plan
- [x] All 24 tests in `test_build_manifest.py` pass (23 existing + 1 new)
- [x] Full test suite: 50 passed, 1 skipped (openai importorskip)