### PR TITLE
ci: add test workflow to run test suite on PRs and pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "test-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Install Playwright browsers
+        run: uv run playwright install chromium --with-deps
+
+      - name: Run tests
+        run: uv run --group dev pytest tests/ -v


### PR DESCRIPTION
## Summary
- **Fixes #42** — No CI workflow previously ran the test suite. Regressions could be merged without detection.
- Adds `.github/workflows/test.yml` that triggers on `push` and `pull_request` to `main`.
- Installs dev dependencies (`uv sync --frozen --group dev`), Playwright browsers, and runs `uv run --group dev pytest tests/ -v`.
- Uses the same patterns as existing workflows: `actions/checkout@v6`, `astral-sh/setup-uv@v7` with caching, concurrency groups with cancel-in-progress.

## Test plan
- [ ] Open a PR — verify the test workflow runs automatically
- [ ] Push to main — verify the test workflow runs
- [ ] Verify YAML syntax is valid (validated locally with Ruby YAML parser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)