### PR TITLE
docs: add progressive disclosure READMEs to every directory

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,9 @@
+# .github/
+
+GitHub-specific configuration for this repository.
+
+## Contents
+
+| Directory | Purpose |
+|-----------|---------|
+| `workflows/` | CI/CD workflows — see [`workflows/README.md`](workflows/README.md) |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,20 @@
+# .github/workflows/
+
+CI/CD workflows that automate transcript fetching, summarisation, testing, and deployment.
+
+## Workflows
+
+| File | Trigger | Purpose |
+|------|---------|---------|
+| `refresh.yml` | Weekdays 06:00 UTC / manual | Fetches new Zoom transcripts, rebuilds `manifest.json`, and commits to `main` |
+| `summarize.yml` | After `refresh.yml` completes / manual | Generates AI summaries (requires `OPENAI_API_KEY` secret), rebuilds manifest, and commits |
+| `pages.yml` | Push to `main` (docs/ changes) or after refresh/summarize | Deploys the `docs/` directory to GitHub Pages |
+| `test.yml` | Every PR and push to `main` | Runs the full test suite with pytest |
+
+## Pipeline flow
+
+```
+refresh.yml  ──►  summarize.yml  ──►  pages.yml
+                                         ▲
+push to main (docs/) ───────────────────┘
+```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 Downloads OpenTelemetry SIG meeting transcripts from Zoom recordings, enriches them with meeting notes from Google Docs, generates AI summaries, and publishes everything as a searchable web UI on GitHub Pages.
 
+## Repository layout
+
+| Path | Description |
+|------|-------------|
+| [`scraper/`](scraper/) | Python package — three-stage transcript extraction pipeline (Sheet → Zoom → Parse) |
+| [`scripts/`](scripts/) | One-off utility scripts (e.g. backfill meeting notes) |
+| [`tests/`](tests/) | Test suite (pytest) |
+| [`docs/`](docs/) | Static site deployed to GitHub Pages (HTML, CSS, JS, and all content) |
+| [`.github/workflows/`](.github/workflows/) | CI/CD — automated fetching, summarisation, testing, and deployment |
+| `main.py` | CLI entry point — orchestrates the full pipeline |
+| `build_site.py` | Builds `docs/manifest.json` from the content tree |
+| `generate_summaries.py` | Generates AI summaries via OpenAI for meetings without one |
+| `Makefile` | Developer shortcuts (`make install`, `make fetch`, `make test`, etc.) |
+
 ## How it works
 
 1. Fetches the public [OTel recordings Google Sheet](https://docs.google.com/spreadsheets/d/1SYKfjYhZdm2Wh2Cl6KVQalKg_m4NhTPZqq-8SzEVO6s) as CSV

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# docs/
+
+Static site served via GitHub Pages at [julianocosta89.github.io/sig-meeting-notes](https://julianocosta89.github.io/sig-meeting-notes/).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `index.html` | Single-page app shell — sidebar navigation, search, and tabbed meeting view |
+| `app.js` | Client-side logic — loads `manifest.json`, renders SIG lists, handles search and URL deep-linking |
+| `style.css` | Styles and theming (light/dark mode) |
+| `manifest.json` | Auto-generated JSON index of all SIGs, meeting dates, durations, and content paths. Built by `build_site.py` |
+| `favicon.svg` | Site favicon |
+| `llms.txt` | Machine-readable site description for LLM crawlers |
+| `robots.txt` | Search engine directives |
+| `.gitkeep` | Ensures the directory is tracked even when empty |
+
+## Subdirectories
+
+| Directory | Contents |
+|-----------|----------|
+| `content/` | All SIG meeting transcripts, notes, and summaries — see [`content/README.md`](content/README.md) |

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -1,0 +1,84 @@
+# docs/content/
+
+Single source of truth for all SIG meeting content. This directory is auto-generated — do not manually edit files here.
+
+## Structure
+
+```
+content/
+  {SIG-Slug}/                  # One directory per SIG (e.g. Collector-SIG, Go-SIG)
+    metadata.md                # Stable SIG metadata (Meeting Notes URL, Repository URL)
+    {YYYY-MM-DD}/              # One directory per meeting date
+      transcript.md            # Zoom recording transcript with header metadata
+      meeting-notes.md         # Attendees and agenda (optional, from Google Docs)
+      summary.md               # AI-generated summary (optional, from gpt-4o-mini)
+```
+
+## How content arrives
+
+1. **`main.py`** writes `transcript.md` (and optionally `meeting-notes.md`) during the fetch stage
+2. **`generate_summaries.py`** adds `summary.md` files for meetings that have transcripts but no summary yet
+3. **`build_site.py`** reads this tree to produce `manifest.json` for the web UI
+
+## Conventions
+
+- **SIG slugs** are derived from the SIG name by stripping special characters and replacing spaces with hyphens. Some slugs are further canonicalised in `scraper/sheet.py` (e.g. `OpenTelemetry-CC-SIG` → `CC-SIG`).
+- **Already-downloaded** transcripts are skipped on subsequent runs — the presence of `transcript.md` is the deduplication signal.
+- **metadata.md** is a simple key-value file (`SIG:`, `Meeting Notes:`, `Repository:`).
+
+## SIGs
+
+<!-- This list is manually maintained. Add new entries when new SIGs appear. -->
+
+`Agent-Management-WG` ·
+`Android-SIG` ·
+`Arrow-SIG` ·
+`Browser-SIG` ·
+`CC-SIG` ·
+`CICD-SemConv-SIG` ·
+`Client-Instrumentation-SIG` ·
+`Collector-SIG` ·
+`Communications-SIG` ·
+`Community-Demo-App-SIG` ·
+`Configuration-WG` ·
+`Contributor-Experience-SIG` ·
+`Developer-Experience-SIG-Meeting` ·
+`eBPF-instrumentation` ·
+`End-User-SIG` ·
+`End-User-SIG-OTel-Blueprints` ·
+`Entities-SIG` ·
+`Event-WG` ·
+`FAAS-WG` ·
+`Go-Auto-Instrumentation-SIG` ·
+`Go-Compile-Time-Instrumentation-SIG` ·
+`Go-SIG` ·
+`Governance-Committee` ·
+`ja-JA-Localization-SIG-Communications` ·
+`Java-Declarative-Configuration` ·
+`Java-SIG` ·
+`JavaScript-SIG` ·
+`K8s-Semantic-Convention-SIG` ·
+`Kotlin-SIG` ·
+`Kubernetes-Operator-SIG` ·
+`LLM-Semantic-Convention-WG` ·
+`NET-Auto-Instr-SIG` ·
+`NET-SIG` ·
+`OpenTelemetry-on-Mainframes-Weekly-Meeting` ·
+`PHP-SIG` ·
+`Profiling-WG` ·
+`Project-Tooling-SIG` ·
+`Prometheus-WG` ·
+`Python-SIG` ·
+`RPC-Sem-Conv-Stability-SIG` ·
+`Ruby-SIG` ·
+`Rust-SIG` ·
+`Sampling-SIG` ·
+`Security-Governance-SIG` ·
+`Semantic-Convention-SIG` ·
+`Semantic-Convention-Tooling` ·
+`Service-and-Deployment-SemConv` ·
+`SIG-Injector` ·
+`Specification-SIG` ·
+`Swift-SIG` ·
+`System-Sem-Conv-Stability-WG` ·
+`Technical-Committee`

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,18 +4,101 @@
 
 ## Resources
 
-- [Web UI](https://julianocosta89.github.io/sig-meeting-notes/): Browse meetings by SIG and date, search transcripts, and read summaries
-- [Manifest](https://julianocosta89.github.io/sig-meeting-notes/manifest.json): JSON index of all SIGs, meeting dates, durations, and metadata
-- [Source](https://github.com/julianocosta89/sig-meeting-notes): Scraper source code, CI workflows, and raw content
+- Web UI: https://julianocosta89.github.io/sig-meeting-notes/
+- Manifest (JSON): https://julianocosta89.github.io/sig-meeting-notes/manifest.json
+- Source: https://github.com/julianocosta89/sig-meeting-notes
 
-## Content structure
+## How to find content
 
-Each meeting is stored under `content/{SIG-Slug}/{YYYY-MM-DD}/` and may contain:
+### 1. Start with the manifest
 
-- `transcript.md` — header metadata and the full Zoom recording transcript
+The manifest lists every SIG and its meetings. Fetch it to discover what is available:
+
+    GET https://julianocosta89.github.io/sig-meeting-notes/manifest.json
+
+Response shape:
+
+    {
+      "generated_at": "2026-02-25T...",
+      "sigs": [
+        {
+          "slug": "Collector-SIG",
+          "name": "Collector SIG",
+          "meeting_notes_url": "https://docs.google.com/document/d/...",
+          "repository_url": "https://github.com/open-telemetry/opentelemetry-collector",
+          "meetings": [
+            { "date": "2026-02-04", "duration_minutes": 42, "has_summary": true },
+            { "date": "2026-02-11", "duration_minutes": 35, "has_summary": true }
+          ]
+        }
+      ]
+    }
+
+### 2. Fetch individual files
+
+Each meeting has up to three files. Build the URL from the SIG slug and date:
+
+    https://julianocosta89.github.io/sig-meeting-notes/content/{SIG-Slug}/{YYYY-MM-DD}/{file}
+
+Files:
+
+- `summary.md` — AI-generated summary (best starting point, short)
 - `meeting-notes.md` — attendees and agenda items
-- `summary.md` — AI-generated summary (gpt-4o-mini)
+- `transcript.md` — full Zoom recording transcript (can be very long)
+
+### 3. Examples
+
+Get the AI summary for the Collector SIG meeting on 2026-02-04:
+
+    GET https://julianocosta89.github.io/sig-meeting-notes/content/Collector-SIG/2026-02-04/summary.md
+
+Get the meeting notes (attendees + agenda) for the same meeting:
+
+    GET https://julianocosta89.github.io/sig-meeting-notes/content/Collector-SIG/2026-02-04/meeting-notes.md
+
+Get the full transcript:
+
+    GET https://julianocosta89.github.io/sig-meeting-notes/content/Collector-SIG/2026-02-04/transcript.md
+
+### 4. Typical workflow
+
+1. Fetch `manifest.json` to find the SIG slug and available dates
+2. Read `summary.md` first — it gives a concise overview of what was discussed
+3. If you need details, read `meeting-notes.md` for the agenda and attendees
+4. Fall back to `transcript.md` only when you need verbatim quotes or the full discussion
+
+## File formats
+
+### transcript.md
+
+    SIG: Collector SIG
+    Date: 2026-02-04
+    Duration: 42 minutes
+    Zoom Recording URL: https://zoom.us/rec/share/...
+    ============================================================
+
+    ## Zoom Recording Transcript
+
+    **Speaker Name** MM:SS utterance text
+
+### meeting-notes.md
+
+    ## Meeting Notes
+
+    ### Attendees
+    - Name 1 (Company)
+    - Name 2 (Company)
+
+    ### Agenda
+    - Item 1
+    - Item 2
+
+### summary.md
+
+    ## Key Topics
+    - Topic 1 summary
+    - Topic 2 summary
 
 ## Coverage
 
-Covers OpenTelemetry SIG meetings from the public [OTel recordings spreadsheet](https://docs.google.com/spreadsheets/d/1SYKfjYhZdm2Wh2Cl6KVQalKg_m4NhTPZqq-8SzEVO6s). New meetings are fetched automatically on weekdays and published to this site.
+Covers OpenTelemetry SIG meetings from the public OTel recordings spreadsheet (https://docs.google.com/spreadsheets/d/1SYKfjYhZdm2Wh2Cl6KVQalKg_m4NhTPZqq-8SzEVO6s). New meetings are fetched automatically on weekdays and published to this site.

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -1,0 +1,15 @@
+# scraper/
+
+Python package that implements the three-stage transcript extraction pipeline.
+
+## Modules
+
+| File | Purpose |
+|------|---------|
+| `sheet.py` | Fetches the public OTel Google Sheet as CSV, parses rows into `Meeting` dataclasses, filters by date range, and normalises SIG slugs via `_CANONICAL_SLUGS` |
+| `zoom.py` | Drives a headless Playwright browser to navigate Zoom recording pages, scrolls the virtual-list container to materialise all `<li>` elements, and extracts the transcript HTML |
+| `transcript.py` | Parses the extracted `<ul class="transcript-list">` HTML with BeautifulSoup into plain-text `"Speaker Name: utterance"` lines |
+| `transcript_io.py` | Shared I/O helpers — canonical header parser and separator constant used by `build_site.py` and `generate_summaries.py` |
+| `community.py` | One-shot community README parser that bootstraps `metadata.md` files by extracting Google Doc meeting-notes URLs from the OTel community repo |
+| `gdoc.py` | Fetches and parses Google Docs to extract attendee lists and agenda items for a given meeting date |
+| `__init__.py` | Package marker (empty) |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+# scripts/
+
+Utility scripts for one-off or maintenance operations. Not part of the regular pipeline.
+
+## Files
+
+| Script | Purpose |
+|--------|---------|
+| `backfill_meeting_notes.py` | Backfills `meeting-notes.md` for transcripts that are missing them. Reads each SIG's `metadata.md` for the Google Doc URL, fetches attendees and agenda, and writes the file. Supports `--execute` (default is dry run), `--force` (overwrite existing), and `--sig` (filter by slug substring). |

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# tests/
+
+Test suite for the project. Run with `make test` or `uv run --group dev pytest tests/ -v`.
+
+## Test files
+
+| File | Covers |
+|------|--------|
+| `test_build_manifest.py` | `build_site.py` — manifest generation from the content tree |
+| `test_community.py` | `scraper/community.py` — community README parsing and metadata bootstrapping |
+| `test_gdoc.py` | `scraper/gdoc.py` — Google Doc fetching and meeting-notes extraction |
+| `test_generate_summaries.py` | `generate_summaries.py` — AI summary generation pipeline |
+| `test_ui.py` | `docs/` web UI — browser-based tests for the single-page app |


### PR DESCRIPTION
## Summary
- Adds a `README.md` to every directory (`.github/`, `.github/workflows/`, `docs/`, `docs/content/`, `scraper/`, `scripts/`, `tests/`) with a short summary and index of contents
- Adds a "Repository layout" table to the root `README.md` linking to each directory
- Updates `docs/llms.txt` with concrete examples showing how LLM agents can discover SIGs via the manifest and fetch individual meeting files
- Lists all 52 SIG slugs in `docs/content/README.md` for easy discoverability

## Test plan
- [ ] Verify each new README renders correctly on GitHub
- [ ] Verify `docs/llms.txt` URLs resolve to real content
- [ ] Verify no existing tests break (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)