### PR TITLE
refactor: reduce nesting depth in send_digest helpers

### DIFF
--- a/scripts/send_digest.py
+++ b/scripts/send_digest.py
@@ -156,28 +156,28 @@ def parse_summary_sections(content: str) -> dict:
     }
 
 
+def _render_summary_lines(summary: dict[str, str]) -> list[str]:
+    """Render a single summary into digest-source lines."""
+    sections = parse_summary_sections(summary["content"])
+    lines = [f"### {summary['slug']} ({summary['date']})"]
+
+    if sections["highlights"]:
+        lines.append("Key topics:")
+        lines.extend(f"- {item}" for item in sections["highlights"])
+
+    if sections["action_items"]:
+        lines.append("Action items:")
+        lines.extend(f"- {item}" for item in sections["action_items"])
+
+    if len(lines) == 1:
+        lines.append(summary["content"].strip())
+
+    return lines
+
+
 def build_digest_source(summaries: list[dict[str, str]]) -> str:
     """Render only digest-relevant summary sections for the model input."""
-    rendered: list[str] = []
-
-    for summary in summaries:
-        sections = parse_summary_sections(summary["content"])
-        lines = [f"### {summary['slug']} ({summary['date']})"]
-
-        if sections["highlights"]:
-            lines.append("Key topics:")
-            lines.extend(f"- {item}" for item in sections["highlights"])
-
-        if sections["action_items"]:
-            lines.append("Action items:")
-            lines.extend(f"- {item}" for item in sections["action_items"])
-
-        if len(lines) == 1:
-            lines.append(summary["content"].strip())
-
-        rendered.append("\n".join(lines))
-
-    return "\n\n".join(rendered)
+    return "\n\n".join("\n".join(_render_summary_lines(s)) for s in summaries)
 
 
 def _get_incomplete_reason(response: object) -> str | None:
@@ -213,6 +213,42 @@ def _request_digest_narrative(client: OpenAI, *, model: str, prompt: str, max_ou
         input=prompt,
         max_output_tokens=max_output_tokens,
     )
+
+
+def _handle_max_tokens_retry(
+    client: OpenAI, *, model: str, prompt: str, original_response: object
+) -> str:
+    """Retry with a higher token budget after a max_output_tokens truncation.
+
+    Returns the best available text, or raises ValueError if unrecoverable.
+    """
+    print("WARNING: OpenAI digest response hit max_output_tokens; retrying once.")
+    retry_response = _request_digest_narrative(
+        client,
+        model=model,
+        prompt=prompt,
+        max_output_tokens=DIGEST_RETRY_MAX_OUTPUT_TOKENS,
+    )
+    if retry_response.status != "incomplete":
+        text = retry_response.output_text
+        if not text:
+            raise ValueError("OpenAI returned no output text")
+        return text.strip()
+
+    retry_reason = _get_incomplete_reason(retry_response)
+    if retry_reason == "max_output_tokens":
+        salvaged = _trim_to_complete_sentences(retry_response.output_text) or (
+            _trim_to_complete_sentences(getattr(original_response, "output_text", ""))
+        )
+        if salvaged:
+            print(
+                "WARNING: OpenAI digest response remained truncated; using completed"
+                " sentences from the partial output."
+            )
+            return salvaged
+
+    suffix = f": {retry_reason}" if retry_reason else ""
+    raise ValueError(f"OpenAI response incomplete{suffix}")
 
 
 def generate_digest_narrative(client: OpenAI, summaries: list[dict[str, str]]) -> str:
@@ -262,33 +298,9 @@ Source material:
     if response.status == "incomplete":
         reason = _get_incomplete_reason(response)
         if reason == "max_output_tokens":
-            print("WARNING: OpenAI digest response hit max_output_tokens; retrying once.")
-            retry_response = _request_digest_narrative(
-                client,
-                model=model,
-                prompt=prompt,
-                max_output_tokens=DIGEST_RETRY_MAX_OUTPUT_TOKENS,
+            return _handle_max_tokens_retry(
+                client, model=model, prompt=prompt, original_response=response
             )
-            if retry_response.status != "incomplete":
-                if not retry_response.output_text:
-                    raise ValueError("OpenAI returned no output text")
-                return retry_response.output_text.strip()
-
-            retry_reason = _get_incomplete_reason(retry_response)
-            if retry_reason == "max_output_tokens":
-                salvaged = _trim_to_complete_sentences(retry_response.output_text) or (
-                    _trim_to_complete_sentences(response.output_text)
-                )
-                if salvaged:
-                    print(
-                        "WARNING: OpenAI digest response remained truncated; using completed"
-                        " sentences from the partial output."
-                    )
-                    return salvaged
-
-            response = retry_response
-            reason = retry_reason
-
         suffix = f": {reason}" if reason else ""
         raise ValueError(f"OpenAI response incomplete{suffix}")
     if not response.output_text:


### PR DESCRIPTION
## What changed
- Extracted `_render_summary_lines` from `build_digest_source` — per-summary rendering is now a standalone function, eliminating generator expressions nested inside a `for` loop
- Extracted `_handle_max_tokens_retry` from `generate_digest_narrative` — the entire retry/salvage block (previously 4 levels deep) is now a top-level helper, capping nesting at 2 levels in both functions
- `generate_digest_narrative` is now a straightforward request → incomplete check → delegate or raise flow

## Why
Datadog static analysis flagged excessive loop/conditional nesting in `send_digest.py` (specifically lines 273–274 and 282–287). Pure code extraction with no behavioural changes.

## Test plan
- [x] `uv run pytest tests/test_send_digest.py` — all 58 tests pass
- [x] All five retry-path tests (`test_incomplete_response_retries_*`, `test_retry_*`) exercise the new `_handle_max_tokens_retry` helper indirectly and continue to pass
- [x] `uv run ruff check .` — no lint errors

Generated with [Claude Code](https://claude.com/claude-code)