### PR TITLE
fix: add explicit __init__ to _NoOpSpan and _NoOpTracer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 *.py[cod]
 *.pyo
 .venv/
+.coverage
+coverage.xml
 
 # macOS
 .DS_Store

--- a/scraper/otel_setup.py
+++ b/scraper/otel_setup.py
@@ -31,6 +31,9 @@ class _Tracer(Protocol):
 
 
 class _NoOpSpan:
+    def __init__(self) -> None:
+        pass
+
     def set_attribute(self, key: str, value: object) -> None:  # noqa: ARG002
         pass
 
@@ -47,6 +50,9 @@ def _noop_ctx() -> Generator[_NoOpSpan]:
 
 
 class _NoOpTracer:
+    def __init__(self) -> None:
+        pass
+
     def start_as_current_span(  # noqa: ARG002
         self, name: str, **kwargs: object
     ) -> contextlib.AbstractContextManager[_NoOpSpan]:


### PR DESCRIPTION
## What changed
- Added `def __init__(self) -> None: pass` to `_NoOpSpan` and `_NoOpTracer` in `scraper/otel_setup.py`
- Added `.coverage` and `coverage.xml` to `.gitignore` to prevent local test artifacts from appearing as untracked files

## Why
Datadog's linter requires classes to have an explicit `__init__` method (bypassed only for dataclass-like decorators). Without it, the linter raises a violation on both no-op classes.

## Test plan
- [ ] All existing `tests/test_otel_setup.py` tests pass (13 tests, no changes needed)
- [ ] `uv run ruff check .` passes clean
- [ ] `uv run ruff format --check .` passes clean

Generated with [Claude Code](https://claude.com/claude-code)