### PR TITLE
refactor: fix duplicate-branch lint in _merge_continuation_lines

### DIFF
--- a/scraper/transcript.py
+++ b/scraper/transcript.py
@@ -97,9 +97,8 @@ def _merge_continuation_lines(raw: list[tuple[bool, str]]) -> list[str]:
     for has_speaker, text in raw[1:]:
         if has_speaker:
             result.append(text)
-        elif (speaker_match := _SPEAKER_LIKE_RE.match(text)) and _is_new_speaker_start(
-            speaker_match
-        ):
+            continue
+        if (speaker_match := _SPEAKER_LIKE_RE.match(text)) and _is_new_speaker_start(speaker_match):
             result.extend(_split_embedded_boundaries(text))
         elif m := _first_embedded_boundary(text):
             # Split at the embedded boundary: the prefix (up to and including the


### PR DESCRIPTION
## What changed
- Converted the `has_speaker` check in `_merge_continuation_lines` from an `if/elif` branch into a guard clause with `continue`
- The downstream `elif` chain becomes a separate `if` statement, so `result.append(text)` no longer appears in two branches of the same conditional

## Why
Datadog static analysis flagged "Code in the branches of an if condition must be unique" because `result.append(text)` appeared identically in both the `has_speaker` branch and the `elif result[-1][-1] in sentence_ends` branch of the same chain.

## Test plan
- [x] `uv run pytest tests/test_transcript.py` — all 69 tests pass
- [x] `uv run ruff format --check . && uv run ruff check .` — no lint errors
- [x] Codex review — no issues found

Generated with [Claude Code](https://claude.com/claude-code)