### PR TITLE
feat: widen transcript window for summary generation

### DIFF
--- a/generate_summaries.py
+++ b/generate_summaries.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 ROOT = Path(__file__).parent
 DOCS_TRANSCRIPTS_DIR = ROOT / "docs" / "content"
 
-MAX_TRANSCRIPT_CHARS = 12_000
+MAX_TRANSCRIPT_CHARS = 80_000
 _API_RATE_LIMIT_S = 1
 
 
@@ -73,7 +73,7 @@ def generate_summary(
             {"role": "user", "content": f"{prompt}\n\n---\n\n{transcript_body}"},
         ],
         temperature=0.3,
-        max_tokens=1024,
+        max_tokens=1500,
     )
     return response.choices[0].message.content
 

--- a/tests/test_generate_summaries.py
+++ b/tests/test_generate_summaries.py
@@ -51,7 +51,7 @@ SAMPLE_TRANSCRIPT_LEGACY = textwrap.dedent("""\
     Tyler 02:20 How's it going?
 """)
 
-LONG_TRANSCRIPT_BODY = f"**Alice** 00:01 {'word ' * 3000}\n"
+LONG_TRANSCRIPT_BODY = f"**Alice** 00:01 {'word ' * 20000}\n"
 LONG_TRANSCRIPT = (
     textwrap.dedent("""\
     SIG: Go SIG
@@ -143,8 +143,8 @@ class TestTranscriptParsing:
         assert "Damien Mathieu 02:19 Hey!" in body
 
     def test_truncate_long_transcript(self, tmp_path: Path) -> None:
-        """Transcripts exceeding ~12,000 chars should be truncated."""
-        assert len(LONG_TRANSCRIPT_BODY) > 12_000
+        """Transcripts exceeding MAX_TRANSCRIPT_CHARS should be truncated."""
+        assert len(LONG_TRANSCRIPT_BODY) > MAX_TRANSCRIPT_CHARS
         p = tmp_path / "long.md"
         p.write_text(LONG_TRANSCRIPT, encoding="utf-8")
         body = read_transcript_body(p)


### PR DESCRIPTION
## What changed
- `generate_summaries.py`: `MAX_TRANSCRIPT_CHARS` 12_000 → 80_000 so the OpenAI summarizer sees a full SIG call (not just the first ~15-20 minutes).
- `generate_summaries.py`: `max_tokens` 1024 → 1500 to leave room for the richer Key Topics/Action Items that longer input now surfaces.
- `tests/test_generate_summaries.py`: bumped the long-transcript fixture so it still exceeds the new limit, and switched the assertion to reference `MAX_TRANSCRIPT_CHARS` instead of a hardcoded value.

## Why
Summaries were biased toward the opening of each meeting because the transcript was hard-truncated at 12k chars — typical 60+ minute SIG calls are 30-60k chars, so most decisions and action items happened past the cutoff. `send_digest.py` consumes the same `summary.md`, so the digest inherits the improvement automatically.

## Test plan
- [x] `uv run pytest tests/test_generate_summaries.py` — 33 passed
- [x] `uv run ruff format . && uv run ruff check . --fix && uv run ruff format --check . && uv run ruff check .` — clean
- [x] `codex review --uncommitted` — no correctness issues
- [ ] Next nightly summarize run produces summaries that reference content from later in long meetings

Generated with [Claude Code](https://claude.com/claude-code)