### PR TITLE
feat: send digest to PRIVATE_EMAIL with DIGEST_TO as bcc

### DIFF
--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -74,6 +74,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          PRIVATE_EMAIL: ${{ secrets.PRIVATE_EMAIL }}
           DIGEST_TO: ${{ secrets.DIGEST_TO }}
           # SHA of the exact commit summarize pushed (empty if nothing was pushed).
           # found=true means this is a workflow_run trigger; found=false means workflow_dispatch.

--- a/scripts/send_digest.py
+++ b/scripts/send_digest.py
@@ -477,7 +477,7 @@ def main() -> None:
 
     with tracer.start_as_current_span("send digest") as span:
         span.set_attribute("digest.summary.count", len(summaries))
-        span.set_attribute("digest.recipient.count", len(bcc_recipients))
+        span.set_attribute("digest.recipient.count", 1 + len(bcc_recipients))
         try:
             client = _create_openai_client(api_key)
             narrative = generate_digest_narrative(client, summaries)

--- a/scripts/send_digest.py
+++ b/scripts/send_digest.py
@@ -7,7 +7,8 @@ meta-summary narrative, and sends the digest via the Resend email API.
 Required env vars:
     OPENAI_API_KEY  — OpenAI API key
     RESEND_API_KEY  — Resend API key
-    DIGEST_TO       — comma-separated list of recipient email addresses
+    PRIVATE_EMAIL   — single visible recipient (``to`` field)
+    DIGEST_TO       — comma-separated list of bcc recipient email addresses
 """
 
 from __future__ import annotations
@@ -371,18 +372,30 @@ def build_email(
     return {"subject": subject, "html": html_body, "text": text_body}
 
 
-def send_email(api_key: str, recipients: list[str], email: dict[str, str]) -> None:
-    """POST the email to the Resend API."""
+def send_email(
+    api_key: str,
+    to_address: str,
+    bcc: list[str],
+    email: dict[str, str],
+) -> None:
+    """POST the email to the Resend API.
+
+    ``to_address`` is the single visible recipient; ``bcc`` is the list of
+    blind-copied recipients (omitted from the payload when empty).
+    """
+    payload: dict[str, object] = {
+        "from": "digest@otelminutes.jcosta.dev",
+        "to": [to_address],
+        "subject": email["subject"],
+        "html": email["html"],
+        "text": email["text"],
+    }
+    if bcc:
+        payload["bcc"] = bcc
     resp = requests.post(
         "https://api.resend.com/emails",
         headers={"Authorization": f"Bearer {api_key}"},
-        json={
-            "from": "digest@otelminutes.jcosta.dev",
-            "to": recipients,
-            "subject": email["subject"],
-            "html": email["html"],
-            "text": email["text"],
-        },
+        json=payload,
         timeout=30,
     )
     if resp.status_code not in (200, 201):
@@ -427,13 +440,18 @@ def main() -> None:
         print("No new summaries, skipping.")
         sys.exit(0)
 
+    private_email = os.environ.get("PRIVATE_EMAIL", "").strip()
+    if not private_email:
+        print("PRIVATE_EMAIL not set, skipping.")
+        sys.exit(0)
+
     digest_to = os.environ.get("DIGEST_TO", "").strip()
     if not digest_to:
         print("DIGEST_TO not set, skipping.")
         sys.exit(0)
 
-    recipients = [r.strip() for r in digest_to.split(",") if r.strip()]
-    if not recipients:
+    bcc_recipients = [r.strip() for r in digest_to.split(",") if r.strip()]
+    if not bcc_recipients:
         print("DIGEST_TO contains no valid addresses, skipping.")
         sys.exit(0)
 
@@ -459,14 +477,14 @@ def main() -> None:
 
     with tracer.start_as_current_span("send digest") as span:
         span.set_attribute("digest.summary.count", len(summaries))
-        span.set_attribute("digest.recipient.count", len(recipients))
+        span.set_attribute("digest.recipient.count", len(bcc_recipients))
         try:
             client = _create_openai_client(api_key)
             narrative = generate_digest_narrative(client, summaries)
 
             today = date.today().isoformat()
             email = build_email(narrative, summaries, today, len(summaries))
-            send_email(resend_key, recipients, email)
+            send_email(resend_key, private_email, bcc_recipients, email)
         except Exception as exc:  # noqa: BLE001
             span.record_exception(exc)
             span.set_status(StatusCode.ERROR, str(exc))

--- a/tests/test_send_digest.py
+++ b/tests/test_send_digest.py
@@ -72,6 +72,7 @@ def _env(**overrides: str) -> dict[str, str]:
     base = {
         "OPENAI_API_KEY": "test-openai-key",
         "RESEND_API_KEY": "test-resend-key",
+        "PRIVATE_EMAIL": "private@example.com",
         "DIGEST_TO": "user@example.com",
     }
     base.update(overrides)
@@ -201,6 +202,7 @@ class TestMain:
                 {
                     "SUMMARIZE_COMMIT_SHA": FAKE_COMMIT_SHA,
                     "SUMMARIZE_COMMIT_FOUND": "true",
+                    "PRIVATE_EMAIL": "private@example.com",
                     "DIGEST_TO": "",
                 },
             ),
@@ -208,6 +210,28 @@ class TestMain:
         ):
             main()
         assert exc_info.value.code == 0
+
+    def test_missing_private_email(self) -> None:
+        """PRIVATE_EMAIL not set -> exits cleanly."""
+        diff_output = "docs/content/Go-SIG/2026-03-05/summary.md\n"
+        with (
+            patch("send_digest.subprocess.run", return_value=_mock_subprocess_result(diff_output)),
+            patch("send_digest._is_trivial_transcript", return_value=False),
+            patch.dict(
+                "os.environ",
+                {
+                    "SUMMARIZE_COMMIT_SHA": FAKE_COMMIT_SHA,
+                    "SUMMARIZE_COMMIT_FOUND": "true",
+                    "PRIVATE_EMAIL": "",
+                    "DIGEST_TO": "user@example.com",
+                },
+            ),
+            patch("send_digest.requests.post") as mock_post,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+        assert exc_info.value.code == 0
+        mock_post.assert_not_called()
 
     def test_missing_resend_api_key(self) -> None:
         """RESEND_API_KEY not set -> exits with error."""
@@ -254,11 +278,12 @@ class TestMain:
         mock_post.assert_called_once()
         call_json = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
         assert call_json["from"] == "digest@otelminutes.jcosta.dev"
-        assert call_json["to"] == ["user@example.com"]
+        assert call_json["to"] == ["private@example.com"]
+        assert call_json["bcc"] == ["user@example.com"]
         assert "Go-SIG" in call_json["subject"] or "1 meetings" in call_json["subject"]
 
     def test_multiple_recipients(self, tmp_path: Path) -> None:
-        """DIGEST_TO with comma-separated list -> to field is a list."""
+        """DIGEST_TO with comma-separated list -> bcc field is a list."""
         mock_client = _mock_openai_client()
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -287,7 +312,8 @@ class TestMain:
             main()
 
         call_json = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
-        assert call_json["to"] == ["a@test.com", "b@test.com", "c@test.com"]
+        assert call_json["to"] == ["private@example.com"]
+        assert call_json["bcc"] == ["a@test.com", "b@test.com", "c@test.com"]
 
     def test_blank_recipients_filtered(self, tmp_path: Path) -> None:
         """Trailing comma or double-comma in DIGEST_TO -> blank entries dropped."""
@@ -319,7 +345,8 @@ class TestMain:
             main()
 
         call_json = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
-        assert call_json["to"] == ["a@test.com", "b@test.com"]
+        assert call_json["to"] == ["private@example.com"]
+        assert call_json["bcc"] == ["a@test.com", "b@test.com"]
 
     def test_resend_error_handling(self, tmp_path: Path) -> None:
         """Resend returns 400 -> error printed, exits non-zero."""
@@ -752,7 +779,10 @@ class TestSendEmail:
         mock_resp.status_code = 200
         with patch("send_digest.requests.post", return_value=mock_resp):
             send_email(
-                "key", ["u@example.com"], {"subject": "S", "html": "<p>test</p>", "text": "test"}
+                "key",
+                "private@example.com",
+                ["u@example.com"],
+                {"subject": "S", "html": "<p>test</p>", "text": "test"},
             )
 
     def test_201_status_succeeds(self) -> None:
@@ -760,7 +790,10 @@ class TestSendEmail:
         mock_resp.status_code = 201
         with patch("send_digest.requests.post", return_value=mock_resp):
             send_email(
-                "key", ["u@example.com"], {"subject": "S", "html": "<p>test</p>", "text": "test"}
+                "key",
+                "private@example.com",
+                ["u@example.com"],
+                {"subject": "S", "html": "<p>test</p>", "text": "test"},
             )
 
     def test_error_status_exits(self) -> None:
@@ -771,9 +804,40 @@ class TestSendEmail:
             with pytest.raises(SystemExit):
                 send_email(
                     "key",
+                    "private@example.com",
                     ["u@example.com"],
                     {"subject": "S", "html": "<p>test</p>", "text": "test"},
                 )
+
+    def test_payload_shape(self) -> None:
+        """to should be a list with the single PRIVATE_EMAIL; bcc carries the digest list."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("send_digest.requests.post", return_value=mock_resp) as mock_post:
+            send_email(
+                "key",
+                "private@example.com",
+                ["a@test.com", "b@test.com"],
+                {"subject": "S", "html": "<p>test</p>", "text": "test"},
+            )
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["to"] == ["private@example.com"]
+        assert call_json["bcc"] == ["a@test.com", "b@test.com"]
+
+    def test_payload_omits_bcc_when_empty(self) -> None:
+        """No bcc list -> bcc key omitted from the Resend payload."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("send_digest.requests.post", return_value=mock_resp) as mock_post:
+            send_email(
+                "key",
+                "private@example.com",
+                [],
+                {"subject": "S", "html": "<p>test</p>", "text": "test"},
+            )
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["to"] == ["private@example.com"]
+        assert "bcc" not in call_json
 
 
 # ---------------------------------------------------------------------------
@@ -788,6 +852,7 @@ class TestMainExtra:
         env = {
             "SUMMARIZE_COMMIT_SHA": FAKE_COMMIT_SHA,
             "SUMMARIZE_COMMIT_FOUND": "true",
+            "PRIVATE_EMAIL": "private@example.com",
             "DIGEST_TO": "user@example.com",
             "OPENAI_API_KEY": "",
             "RESEND_API_KEY": "key",


### PR DESCRIPTION
## What changed
- `scripts/send_digest.py`: `send_email()` now takes a `to_address` plus a `bcc` list; payload puts the new `PRIVATE_EMAIL` secret in `to` and the parsed `DIGEST_TO` list in `bcc` (omitted when empty).
- `main()` reads `PRIVATE_EMAIL` and skips cleanly if it is unset, matching the existing `DIGEST_TO` skip behaviour.
- `.github/workflows/digest.yml`: pass `PRIVATE_EMAIL: ${{ secrets.PRIVATE_EMAIL }}` to the send step.
- `tests/test_send_digest.py`: `_env()` now includes `PRIVATE_EMAIL`; added `test_missing_private_email`, updated recipient assertions to check `to == [PRIVATE_EMAIL]` and `bcc == [...]`, and added `TestSendEmail` cases for payload shape and the empty-bcc path.

## Why
Recipients on the digest should not see each other's addresses — switching to a single visible `to` (the maintainer) with everyone else in `bcc` removes that leak.

## Test plan
- [x] `uv run ruff format . && uv run ruff check . --fix && uv run ruff format --check . && uv run ruff check .` — all clean
- [x] `uv run pytest tests/test_send_digest.py` — 61 passed
- [ ] Owner action: add `PRIVATE_EMAIL` secret in repo Settings → Secrets → Actions before the next digest run
- [ ] After merge, trigger `Daily Digest` via `workflow_dispatch` and confirm the delivered email shows only `PRIVATE_EMAIL` in the `To:` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)