### PR TITLE
fix: parenthesize except clause in _resolve_sig

### DIFF
--- a/main.py
+++ b/main.py
@@ -291,7 +291,7 @@ def _resolve_sig(meetings: list[Meeting], sig_filter: str) -> str | None:
             print(f"Please enter a number between 1 and {len(matched)}.")
         except ValueError:
             print("Invalid input — please enter a number.")
-        except EOFError, KeyboardInterrupt:
+        except (EOFError, KeyboardInterrupt):  # fmt: skip
             print("\nAborted.")
             return None
 


### PR DESCRIPTION
## Summary
- `_resolve_sig()` in `main.py` had `except EOFError, KeyboardInterrupt:` — Python 2 syntax that reads like a bug.
- Turns out it doesn't actually crash: this repo requires `python>=3.14`, and in this Python 3.14.0 build the bare-comma form parses as a tuple (`(EOFError, KeyboardInterrupt)`) and behaves correctly at runtime. Confirmed via `ast.dump`/`dis.dis`.
- However, `ruff format` treats `except (A, B):` as having "redundant" parens and strips them back to the ambiguous unparenthesized form on every format pass — so simply adding parens doesn't stick.
- Fixed by pinning the parenthesized, unambiguous form with `# fmt: skip` so it survives formatting while staying valid and readable.

## Test plan
- [x] `uv run ruff format . && uv run ruff check . --fix && uv run ruff format --check . && uv run ruff check .` — all clean
- [x] `uv run pytest -q` — 626 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)