### PR TITLE
feat: simplify daily digest to key-topic tiles only, remove AI narrative

### DIFF
--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -72,7 +72,6 @@ jobs:
 
       - name: Send daily digest
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           PRIVATE_EMAIL: ${{ secrets.PRIVATE_EMAIL }}
           DIGEST_TO: ${{ secrets.DIGEST_TO }}

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -24,7 +24,7 @@ jobs:
   digest:
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.head_repository.full_name == github.repository &&
        github.event.workflow_run.head_branch == 'main' &&

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.ref }}
           fetch-depth: 0          # full history so SUMMARIZE_COMMIT_SHA~1 is always reachable for git diff
 
       - name: Download summary commit SHA artifact

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -24,7 +24,7 @@ jobs:
   digest:
     runs-on: ubuntu-latest
     if: >-
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.head_repository.full_name == github.repository &&
        github.event.workflow_run.head_branch == 'main' &&

--- a/scripts/digest_template.html
+++ b/scripts/digest_template.html
@@ -57,31 +57,6 @@
           </td>
         </tr>
 
-        <!-- AI narrative callout -->
-        <tr>
-          <td style="padding: 16px 24px 0;">
-            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" style="background-color: #fffbeb; border: 1px solid #f0d060; border-radius: 6px;">
-              <tr>
-                <td style="padding: 14px 16px;">
-                  <div style="font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.6px; color: #a07010; margin-bottom: 8px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;">Today across OTel</div>
-                  <p style="margin: 0; font-size: 14px; line-height: 1.65; color: #1f2328; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;">{{ narrative }}</p>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-
-        <!-- Horizontal rule -->
-        <tr>
-          <td style="padding: 20px 24px 0;">
-            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
-              <tr>
-                <td style="border-top: 1px solid #d1d9e0; font-size: 1px; line-height: 1px;">&nbsp;</td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-
         <!-- Meeting cards -->
         {% for meeting in meetings %}
         <tr>

--- a/scripts/send_digest.py
+++ b/scripts/send_digest.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""Send a daily digest email summarising new OTel SIG meeting summaries.
+"""Send a daily digest email with key topics from new OTel SIG meeting summaries.
 
-Detects new summary.md files via ``git diff``, asks OpenAI to produce a
-meta-summary narrative, and sends the digest via the Resend email API.
+Detects new summary.md files via ``git diff`` and sends the digest via the
+Resend email API.
 
 Required env vars:
-    OPENAI_API_KEY  — OpenAI API key
     RESEND_API_KEY  — Resend API key
     PRIVATE_EMAIL   — single visible recipient (``to`` field)
     DIGEST_TO       — comma-separated list of bcc recipient email addresses
@@ -18,7 +17,6 @@ import subprocess
 import sys
 from datetime import date
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import requests
 
@@ -30,16 +28,9 @@ from scraper.transcript_io import (
     read_transcript_body,
 )
 
-if TYPE_CHECKING:
-    from openai import OpenAI
-
-
 ROOT = Path(__file__).resolve().parent.parent
 SITE_BASE_URL = "https://otelminutes.jcosta.dev/"
 LOGO_URL = "https://raw.githubusercontent.com/julianocosta89/sig-meeting-notes/refs/heads/main/docs/OTelMinutes-logo.png"
-DEFAULT_DIGEST_MODEL = "gpt-5-mini"
-DIGEST_MAX_OUTPUT_TOKENS = 2048
-DIGEST_RETRY_MAX_OUTPUT_TOKENS = 4096
 
 
 def _run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -157,158 +148,6 @@ def parse_summary_sections(content: str) -> dict:
     }
 
 
-def _render_summary_lines(summary: dict[str, str]) -> list[str]:
-    """Render a single summary into digest-source lines."""
-    sections = parse_summary_sections(summary["content"])
-    lines = [f"### {summary['slug']} ({summary['date']})"]
-
-    if sections["highlights"]:
-        lines.append("Key topics:")
-        lines.extend(f"- {item}" for item in sections["highlights"])
-
-    if sections["action_items"]:
-        lines.append("Action items:")
-        lines.extend(f"- {item}" for item in sections["action_items"])
-
-    if len(lines) == 1:
-        lines.append(summary["content"].strip())
-
-    return lines
-
-
-def build_digest_source(summaries: list[dict[str, str]]) -> str:
-    """Render only digest-relevant summary sections for the model input."""
-    return "\n\n".join("\n".join(_render_summary_lines(s)) for s in summaries)
-
-
-def _get_incomplete_reason(response: object) -> str | None:
-    """Extract the incomplete reason from a Responses API object."""
-    details = getattr(response, "incomplete_details", None)
-    if isinstance(details, dict):
-        return details.get("reason")
-    if details is not None:
-        return getattr(details, "reason", None)
-    return None
-
-
-def _trim_to_complete_sentences(text: str) -> str:
-    """Return only the completed sentence prefix from a truncated response."""
-    stripped = text.strip()
-    if not stripped:
-        return ""
-
-    last_sentence_end = max(stripped.rfind("."), stripped.rfind("!"), stripped.rfind("?"))
-    if last_sentence_end == -1:
-        return ""
-    return stripped[: last_sentence_end + 1].strip()
-
-
-def _request_digest_narrative(client: OpenAI, *, model: str, prompt: str, max_output_tokens: int):
-    """Issue a digest generation request to OpenAI."""
-    return client.responses.create(
-        model=model,
-        instructions=(
-            "You are an editor writing a concise daily digest for the OpenTelemetry"
-            " community. Prefer concrete, neutral prose over hype."
-        ),
-        input=prompt,
-        max_output_tokens=max_output_tokens,
-    )
-
-
-def _handle_max_tokens_retry(
-    client: OpenAI, *, model: str, prompt: str, original_response: object
-) -> str:
-    """Retry with a higher token budget after a max_output_tokens truncation.
-
-    Returns the best available text, or raises ValueError if unrecoverable.
-    """
-    print("WARNING: OpenAI digest response hit max_output_tokens; retrying once.")
-    retry_response = _request_digest_narrative(
-        client,
-        model=model,
-        prompt=prompt,
-        max_output_tokens=DIGEST_RETRY_MAX_OUTPUT_TOKENS,
-    )
-    if retry_response.status != "incomplete":
-        text = retry_response.output_text
-        if not text:
-            raise ValueError("OpenAI returned no output text")
-        return text.strip()
-
-    retry_reason = _get_incomplete_reason(retry_response)
-    if retry_reason == "max_output_tokens":
-        salvaged = _trim_to_complete_sentences(retry_response.output_text) or (
-            _trim_to_complete_sentences(getattr(original_response, "output_text", ""))
-        )
-        if salvaged:
-            print(
-                "WARNING: OpenAI digest response remained truncated; using completed"
-                " sentences from the partial output."
-            )
-            return salvaged
-
-    suffix = f": {retry_reason}" if retry_reason else ""
-    raise ValueError(f"OpenAI response incomplete{suffix}")
-
-
-def generate_digest_narrative(client: OpenAI, summaries: list[dict[str, str]]) -> str:
-    """Call OpenAI to produce a concise cross-SIG narrative."""
-    combined = build_digest_source(summaries)
-    model = os.environ.get("OPENAI_DIGEST_MODEL", DEFAULT_DIGEST_MODEL).strip() or (
-        DEFAULT_DIGEST_MODEL
-    )
-
-    if len(summaries) == 1:
-        user_prompt = """Write a 2-3 sentence email-ready digest paragraph
-about this OpenTelemetry SIG meeting.
-
-Focus on the most important themes and decisions discussed.
-Use plain, direct language. Avoid fancy or unusual vocabulary.
-Do not use imperative language or tell the reader to do anything.
-Do not mention any person's name or attribute anything to a specific individual.
-Do not use markdown, bullets, or headings.
-Do not mention that you were given summaries.
-Do not invent details that are not present in the source material.
-
-Source material:
-"""
-    else:
-        user_prompt = """Write a single 3-4 sentence email-ready digest paragraph
-connecting these OpenTelemetry SIG meetings.
-
-Synthesize shared themes, dependencies, and ongoing work across meetings.
-Do not turn the paragraph into a meeting-by-meeting list.
-Only mention SIG names when they materially help clarity.
-Use plain, direct language. Avoid fancy or unusual vocabulary.
-Do not use imperative language or tell the reader to do anything.
-Do not mention any person's name or attribute anything to a specific individual.
-Do not use markdown, bullets, or headings.
-Do not mention that you were given summaries.
-Do not invent details that are not present in the source material.
-
-Source material:
-"""
-    prompt = f"{user_prompt}\n\n{combined}"
-    response = _request_digest_narrative(
-        client,
-        model=model,
-        prompt=prompt,
-        max_output_tokens=DIGEST_MAX_OUTPUT_TOKENS,
-    )
-    if response.status == "incomplete":
-        reason = _get_incomplete_reason(response)
-        if reason == "max_output_tokens":
-            return _handle_max_tokens_retry(
-                client, model=model, prompt=prompt, original_response=response
-            )
-        suffix = f": {reason}" if reason else ""
-        raise ValueError(f"OpenAI response incomplete{suffix}")
-    if not response.output_text:
-        raise ValueError("OpenAI returned no output text")
-    return response.output_text.strip()
-
-
 def build_deep_link(slug: str, meeting_date: str) -> str:
     """Build a deep-link URL to the meeting on the site."""
     return f"{SITE_BASE_URL}?sig={slug}&date={meeting_date}"
@@ -328,7 +167,7 @@ def _render_html(template_vars: dict) -> str:  # pragma: no cover
 
 
 def build_email(
-    narrative: str, summaries: list[dict[str, str]], today: str, count: int
+    summaries: list[dict[str, str]], today: str, count: int
 ) -> dict[str, str]:
     """Build subject, HTML body, and plain-text body for the digest email."""
     subject = f"OTel SIG Daily Digest — {today} ({count} meetings)"
@@ -351,7 +190,6 @@ def build_email(
     # HTML body via Jinja2 template
     html_body = _render_html(
         {
-            "narrative": narrative,
             "date": today,
             "count": count,
             "meetings": meetings,
@@ -360,7 +198,7 @@ def build_email(
     )
 
     # Plain-text body
-    text_parts = ["OTel SIG Daily Digest", "", narrative, "", "---", ""]
+    text_parts = ["OTel SIG Daily Digest", "", "---", ""]
     for m in meetings:
         text_parts.append(f"{m['slug']} — {m['date']}")
         text_parts.append(m["content"])
@@ -425,13 +263,6 @@ def _is_trivial_transcript(summary_path: str, commit_sha: str = "") -> bool:
     return count_transcript_lines(body) < MIN_TRANSCRIPT_LINES
 
 
-def _create_openai_client(api_key: str) -> OpenAI:
-    """Create an OpenAI client instance (seam for testing)."""
-    from openai import OpenAI as _OpenAI  # noqa: PLC0415  # pragma: no cover
-
-    return _OpenAI(api_key=api_key)  # pragma: no cover
-
-
 def main() -> None:
     tracer = configure_tracer("otel-recordings-digest")
 
@@ -455,11 +286,6 @@ def main() -> None:
         print("DIGEST_TO contains no valid addresses, skipping.")
         sys.exit(0)
 
-    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
-    if not api_key:
-        print("ERROR: OPENAI_API_KEY not set")
-        sys.exit(1)
-
     resend_key = os.environ.get("RESEND_API_KEY", "").strip()
     if not resend_key:
         print("ERROR: RESEND_API_KEY not set")
@@ -479,11 +305,8 @@ def main() -> None:
         span.set_attribute("digest.summary.count", len(summaries))
         span.set_attribute("digest.recipient.count", 1 + len(bcc_recipients))
         try:
-            client = _create_openai_client(api_key)
-            narrative = generate_digest_narrative(client, summaries)
-
             today = date.today().isoformat()
-            email = build_email(narrative, summaries, today, len(summaries))
+            email = build_email(summaries, today, len(summaries))
             send_email(resend_key, private_email, bcc_recipients, email)
         except Exception as exc:  # noqa: BLE001
             span.record_exception(exc)

--- a/scripts/send_digest.py
+++ b/scripts/send_digest.py
@@ -197,11 +197,13 @@ def build_email(
         }
     )
 
-    # Plain-text body
+    # Plain-text body — key topics only, matching the HTML tiles
     text_parts = ["OTel SIG Daily Digest", "", "---", ""]
     for m in meetings:
         text_parts.append(f"{m['slug']} — {m['date']}")
-        text_parts.append(m["content"])
+        if m["highlights"]:
+            for item in m["highlights"]:
+                text_parts.append(f"- {item}")
         text_parts.append(f"Read more: {m['link']}")
         text_parts.append("")
 

--- a/scripts/send_digest.py
+++ b/scripts/send_digest.py
@@ -166,9 +166,7 @@ def _render_html(template_vars: dict) -> str:  # pragma: no cover
     return template.render(**template_vars)
 
 
-def build_email(
-    summaries: list[dict[str, str]], today: str, count: int
-) -> dict[str, str]:
+def build_email(summaries: list[dict[str, str]], today: str, count: int) -> dict[str, str]:
     """Build subject, HTML body, and plain-text body for the digest email."""
     subject = f"OTel SIG Daily Digest — {today} ({count} meetings)"
 

--- a/tests/test_send_digest.py
+++ b/tests/test_send_digest.py
@@ -1,7 +1,7 @@
 """Tests for scripts/send_digest.py — daily digest email.
 
-These tests mock subprocess, OpenAI, requests, and env vars so no
-API keys or network access are needed.
+These tests mock subprocess, requests, and env vars so no API keys or
+network access are needed.
 """
 
 from __future__ import annotations
@@ -18,15 +18,9 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from send_digest import (  # noqa: E402
-    DIGEST_MAX_OUTPUT_TOKENS,
-    DIGEST_RETRY_MAX_OUTPUT_TOKENS,
-    _get_incomplete_reason,
     _is_trivial_transcript,
-    _trim_to_complete_sentences,
     build_deep_link,
-    build_digest_source,
     build_email,
-    generate_digest_narrative,
     get_new_summary_paths,
     main,
     parse_summary_info,
@@ -37,8 +31,6 @@ from send_digest import (  # noqa: E402
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-FAKE_NARRATIVE = "Today the OTel community discussed collector improvements and SDK updates."
 
 SAMPLE_SUMMARY = textwrap.dedent("""\
     ## Key Topics
@@ -57,20 +49,9 @@ GIT_DIFF_OUTPUT = (
 )
 
 
-def _mock_openai_client(response_text: str = FAKE_NARRATIVE) -> MagicMock:
-    mock_response = MagicMock()
-    mock_response.output_text = response_text
-    mock_response.status = "completed"
-    mock_response.incomplete_details = None
-    mock_client = MagicMock()
-    mock_client.responses.create.return_value = mock_response
-    return mock_client
-
-
 def _env(**overrides: str) -> dict[str, str]:
     """Return a base env dict with all required keys, updated with overrides."""
     base = {
-        "OPENAI_API_KEY": "test-openai-key",
         "RESEND_API_KEY": "test-resend-key",
         "PRIVATE_EMAIL": "private@example.com",
         "DIGEST_TO": "user@example.com",
@@ -250,8 +231,7 @@ class TestMain:
         assert exc_info.value.code == 1
 
     def test_happy_path(self, tmp_path: Path) -> None:
-        """New summaries found -> OpenAI called -> Resend POST made."""
-        mock_client = _mock_openai_client()
+        """New summaries found -> Resend POST made."""
         mock_resp = MagicMock()
         mock_resp.status_code = 200
 
@@ -268,13 +248,11 @@ class TestMain:
             ),
             patch("send_digest.os.environ.get", side_effect=lambda k, d="": env.get(k, d)),
             patch("send_digest._is_trivial_transcript", return_value=False),
-            patch("send_digest._create_openai_client", return_value=mock_client),
             patch("send_digest._render_html", return_value="<html>mock</html>"),
             patch("send_digest.requests.post", return_value=mock_resp) as mock_post,
         ):
             main()
 
-        mock_client.responses.create.assert_called_once()
         mock_post.assert_called_once()
         call_json = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
         assert call_json["from"] == "digest@otelminutes.jcosta.dev"
@@ -284,7 +262,6 @@ class TestMain:
 
     def test_multiple_recipients(self, tmp_path: Path) -> None:
         """DIGEST_TO with comma-separated list -> bcc field is a list."""
-        mock_client = _mock_openai_client()
         mock_resp = MagicMock()
         mock_resp.status_code = 200
 
@@ -305,7 +282,6 @@ class TestMain:
             ),
             patch("send_digest.os.environ.get", side_effect=lambda k, d="": env.get(k, d)),
             patch("send_digest._is_trivial_transcript", return_value=False),
-            patch("send_digest._create_openai_client", return_value=mock_client),
             patch("send_digest._render_html", return_value="<html>mock</html>"),
             patch("send_digest.requests.post", return_value=mock_resp) as mock_post,
         ):
@@ -317,7 +293,6 @@ class TestMain:
 
     def test_blank_recipients_filtered(self, tmp_path: Path) -> None:
         """Trailing comma or double-comma in DIGEST_TO -> blank entries dropped."""
-        mock_client = _mock_openai_client()
         mock_resp = MagicMock()
         mock_resp.status_code = 200
 
@@ -338,7 +313,6 @@ class TestMain:
             ),
             patch("send_digest.os.environ.get", side_effect=lambda k, d="": env.get(k, d)),
             patch("send_digest._is_trivial_transcript", return_value=False),
-            patch("send_digest._create_openai_client", return_value=mock_client),
             patch("send_digest._render_html", return_value="<html>mock</html>"),
             patch("send_digest.requests.post", return_value=mock_resp) as mock_post,
         ):
@@ -350,7 +324,6 @@ class TestMain:
 
     def test_resend_error_handling(self, tmp_path: Path) -> None:
         """Resend returns 400 -> error printed, exits non-zero."""
-        mock_client = _mock_openai_client()
         mock_resp = MagicMock()
         mock_resp.status_code = 400
         mock_resp.text = "Bad Request"
@@ -368,7 +341,6 @@ class TestMain:
             ),
             patch("send_digest.os.environ.get", side_effect=lambda k, d="": env.get(k, d)),
             patch("send_digest._is_trivial_transcript", return_value=False),
-            patch("send_digest._create_openai_client", return_value=mock_client),
             patch("send_digest._render_html", return_value="<html>mock</html>"),
             patch("send_digest.requests.post", return_value=mock_resp),
             pytest.raises(SystemExit) as exc_info,
@@ -396,7 +368,7 @@ class TestMain:
         assert exc_info.value.code == 1
 
     def test_span_records_exception_on_error(self) -> None:
-        """When generate_digest_narrative raises, the exception is re-raised from main()."""
+        """When build_email raises, the exception is re-raised from main()."""
         env = _env(SUMMARIZE_COMMIT_SHA=FAKE_COMMIT_SHA, SUMMARIZE_COMMIT_FOUND="true")
         diff_output = "docs/content/Go-SIG/2026-03-05/summary.md\n"
 
@@ -410,12 +382,11 @@ class TestMain:
             ),
             patch("send_digest.os.environ.get", side_effect=lambda k, d="": env.get(k, d)),
             patch("send_digest._is_trivial_transcript", return_value=False),
-            patch("send_digest._create_openai_client", return_value=MagicMock()),
             patch(
-                "send_digest.generate_digest_narrative",
-                side_effect=RuntimeError("OpenAI unavailable"),
+                "send_digest.build_email",
+                side_effect=RuntimeError("email build failed"),
             ),
-            pytest.raises(RuntimeError, match="OpenAI unavailable"),
+            pytest.raises(RuntimeError, match="email build failed"),
         ):
             main()
 
@@ -430,7 +401,7 @@ class TestBuildEmail:
             {"slug": "Collector-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY},
         ]
         with patch("send_digest._render_html", return_value="<html>mock</html>"):
-            email = build_email(FAKE_NARRATIVE, summaries, "2026-03-05", 2)
+            email = build_email(summaries, "2026-03-05", 2)
         assert "2026-03-05" in email["subject"]
         assert "2 meetings" in email["subject"]
 
@@ -441,7 +412,7 @@ class TestBuildEmail:
             {"slug": "Collector-SIG", "date": "2026-03-06", "content": SAMPLE_SUMMARY},
         ]
         with patch("send_digest._render_html", return_value="<html>mock</html>"):
-            email = build_email(FAKE_NARRATIVE, summaries, "2026-03-05", 2)
+            email = build_email(summaries, "2026-03-05", 2)
         assert "?sig=Go-SIG&date=2026-03-05" in email["text"]
         assert "?sig=Collector-SIG&date=2026-03-06" in email["text"]
 
@@ -455,220 +426,37 @@ class TestBuildEmail:
             return "<html>mock</html>"
 
         with patch("send_digest._render_html", side_effect=_capture_render):
-            build_email(FAKE_NARRATIVE, summaries, "2026-03-05", 1)
+            build_email(summaries, "2026-03-05", 1)
 
         meetings = captured[0]["meetings"]  # type: ignore[index]
         assert len(meetings) == 1
         assert "highlights" in meetings[0]
         assert meetings[0]["highlights"] == ["Discussed collector stability"]
 
-
-class TestGenerateDigestNarrative:
-    """Tests for OpenAI narrative generation."""
-
-    def test_calls_openai(self) -> None:
-        """OpenAI should be called with the combined summaries."""
-        mock_client = _mock_openai_client()
+    def test_no_narrative_in_template_vars(self) -> None:
+        """Template vars should not contain a 'narrative' key."""
         summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-        result = generate_digest_narrative(mock_client, summaries)
-        mock_client.responses.create.assert_called_once()
-        assert result == FAKE_NARRATIVE
+        captured: list[dict] = []
 
-    def test_missing_output_text_raises_value_error(self) -> None:
-        """Blank output_text from OpenAI should raise ValueError."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.output_text = ""
-        mock_response.status = "completed"
-        mock_response.incomplete_details = None
-        mock_client.responses.create.return_value = mock_response
+        def _capture_render(template_vars: dict) -> str:
+            captured.append(template_vars)
+            return "<html>mock</html>"
+
+        with patch("send_digest._render_html", side_effect=_capture_render):
+            build_email(summaries, "2026-03-05", 1)
+
+        assert "narrative" not in captured[0]
+
+    def test_no_narrative_in_text_body(self) -> None:
+        """Plain-text body should not contain a narrative paragraph."""
         summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-        with pytest.raises(ValueError):
-            generate_digest_narrative(mock_client, summaries)
-
-    def test_incomplete_response_raises_value_error(self) -> None:
-        """Non-token-limit incomplete responses should still fail."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.output_text = "Partial digest"
-        mock_response.status = "incomplete"
-        mock_response.incomplete_details = {"reason": "content_filter"}
-        mock_client.responses.create.return_value = mock_response
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-        with pytest.raises(ValueError, match="content_filter"):
-            generate_digest_narrative(mock_client, summaries)
-
-    def test_incomplete_response_retries_when_limited_by_output_tokens(self) -> None:
-        """Token-limit truncation should retry with a larger output budget."""
-        mock_client = MagicMock()
-        first = MagicMock()
-        first.output_text = "Partial digest"
-        first.status = "incomplete"
-        first.incomplete_details = {"reason": "max_output_tokens"}
-        second = MagicMock()
-        second.output_text = FAKE_NARRATIVE
-        second.status = "completed"
-        second.incomplete_details = None
-        mock_client.responses.create.side_effect = [first, second]
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-
-        result = generate_digest_narrative(mock_client, summaries)
-
-        assert result == FAKE_NARRATIVE
-        first_call = mock_client.responses.create.call_args_list[0].kwargs
-        second_call = mock_client.responses.create.call_args_list[1].kwargs
-        assert first_call["max_output_tokens"] == DIGEST_MAX_OUTPUT_TOKENS
-        assert second_call["max_output_tokens"] == DIGEST_RETRY_MAX_OUTPUT_TOKENS
-
-    def test_incomplete_response_with_object_details_can_salvage_output(self) -> None:
-        """Object-style incomplete_details should still allow truncation recovery."""
-        mock_client = MagicMock()
-        first = MagicMock()
-        first.output_text = "Partial digest without punctuation"
-        first.status = "incomplete"
-        details = MagicMock(spec=["reason"])
-        details.reason = "max_output_tokens"
-        first.incomplete_details = details
-        second = MagicMock()
-        second.output_text = "Sentence one. Sentence two without ending"
-        second.status = "incomplete"
-        second.incomplete_details = details
-        mock_client.responses.create.side_effect = [first, second]
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-
-        result = generate_digest_narrative(mock_client, summaries)
-
-        assert result == "Sentence one."
-
-    def test_retry_completed_without_output_text_raises_value_error(self) -> None:
-        """A successful retry still needs output text."""
-        mock_client = MagicMock()
-        first = MagicMock()
-        first.output_text = "Partial digest"
-        first.status = "incomplete"
-        first.incomplete_details = {"reason": "max_output_tokens"}
-        second = MagicMock()
-        second.output_text = ""
-        second.status = "completed"
-        second.incomplete_details = None
-        mock_client.responses.create.side_effect = [first, second]
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-
-        with pytest.raises(ValueError, match="no output text"):
-            generate_digest_narrative(mock_client, summaries)
-
-    def test_retry_incomplete_without_salvage_raises_value_error(self) -> None:
-        """If both responses are truncated with no complete sentence, fail clearly."""
-        mock_client = MagicMock()
-        first = MagicMock()
-        first.output_text = "Partial"
-        first.status = "incomplete"
-        first.incomplete_details = {"reason": "max_output_tokens"}
-        second = MagicMock()
-        second.output_text = "Still partial"
-        second.status = "incomplete"
-        second.incomplete_details = {"reason": "max_output_tokens"}
-        mock_client.responses.create.side_effect = [first, second]
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-
-        with pytest.raises(ValueError, match="max_output_tokens"):
-            generate_digest_narrative(mock_client, summaries)
-
-    def test_retry_incomplete_for_non_token_reason_raises_not_salvages(self) -> None:
-        """Retry incomplete due to a non-token reason must raise, not salvage partial text."""
-        mock_client = MagicMock()
-        first = MagicMock()
-        first.output_text = "Partial digest"
-        first.status = "incomplete"
-        first.incomplete_details = {"reason": "max_output_tokens"}
-        second = MagicMock()
-        second.output_text = "Sentence one. Sentence two without ending"
-        second.status = "incomplete"
-        second.incomplete_details = {"reason": "content_filter"}
-        mock_client.responses.create.side_effect = [first, second]
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-
-        with pytest.raises(ValueError, match="content_filter"):
-            generate_digest_narrative(mock_client, summaries)
-
-    def test_single_meeting_uses_summary_prompt(self) -> None:
-        """One-meeting input should not ask for cross-SIG correlations."""
-        mock_client = _mock_openai_client()
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-        generate_digest_narrative(mock_client, summaries)
-        call_kwargs = mock_client.responses.create.call_args[1]
-        user_msg = call_kwargs["input"]
-        assert "shared themes" not in user_msg
-        assert "meeting-by-meeting list" not in user_msg
-        assert "2-3 sentence" in user_msg
-
-    def test_multi_meeting_uses_cross_sig_prompt(self) -> None:
-        """Multiple meetings should get the cross-SIG correlation prompt."""
-        mock_client = _mock_openai_client()
-        summaries = [
-            {"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY},
-            {"slug": "Collector-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY},
-        ]
-        generate_digest_narrative(mock_client, summaries)
-        call_kwargs = mock_client.responses.create.call_args[1]
-        user_msg = call_kwargs["input"]
-        assert "shared themes" in user_msg
-        assert "meeting-by-meeting list" in user_msg
-
-    def test_uses_current_digest_model_default(self) -> None:
-        """Digest generation should default to the current configured model constant."""
-        mock_client = _mock_openai_client()
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-        generate_digest_narrative(mock_client, summaries)
-        call_kwargs = mock_client.responses.create.call_args[1]
-        assert call_kwargs["model"] == "gpt-5-mini"
-        assert "temperature" not in call_kwargs
-
-    def test_respects_digest_model_override(self) -> None:
-        """OPENAI_DIGEST_MODEL should override the default model alias."""
-        mock_client = _mock_openai_client()
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-        with patch.dict("os.environ", {"OPENAI_DIGEST_MODEL": "gpt-5.4-mini"}):
-            generate_digest_narrative(mock_client, summaries)
-        call_kwargs = mock_client.responses.create.call_args[1]
-        assert call_kwargs["model"] == "gpt-5.4-mini"
-
-    def test_uses_larger_output_budget(self) -> None:
-        """The digest budget should leave room for a full paragraph."""
-        mock_client = _mock_openai_client()
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-        generate_digest_narrative(mock_client, summaries)
-        call_kwargs = mock_client.responses.create.call_args[1]
-        assert call_kwargs["max_output_tokens"] == DIGEST_MAX_OUTPUT_TOKENS
-
-
-class TestBuildDigestSource:
-    def test_uses_only_digest_relevant_sections(self) -> None:
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
-        result = build_digest_source(summaries)
-        assert "Key topics:" in result
-        assert "Action items:" in result
-        assert "Participants" not in result
-
-    def test_fallback_to_full_content_when_no_sections(self) -> None:
-        """When a summary has no highlights or action items, use the raw content."""
-        content = "Some freeform summary text with no structured sections."
-        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": content}]
-        result = build_digest_source(summaries)
-        assert content in result
-
-
-class TestDigestHelpers:
-    def test_get_incomplete_reason_returns_none_when_missing(self) -> None:
-        response = MagicMock()
-        response.incomplete_details = None
-        assert _get_incomplete_reason(response) is None
-
-    def test_trim_to_complete_sentences_empty_input(self) -> None:
-        assert _trim_to_complete_sentences("   ") == ""
-
-    def test_trim_to_complete_sentences_without_punctuation(self) -> None:
-        assert _trim_to_complete_sentences("unfinished sentence") == ""
+        with patch("send_digest._render_html", return_value="<html>mock</html>"):
+            email = build_email(summaries, "2026-03-05", 1)
+        # Text body should start with title, then separator, then meetings
+        lines = email["text"].splitlines()
+        assert lines[0] == "OTel SIG Daily Digest"
+        assert lines[1] == ""
+        assert lines[2] == "---"
 
 
 # ---------------------------------------------------------------------------
@@ -846,26 +634,6 @@ class TestSendEmail:
 
 
 class TestMainExtra:
-    def test_missing_openai_api_key(self) -> None:
-        """OPENAI_API_KEY not set → exits with error."""
-        diff_output = "docs/content/Go-SIG/2026-03-05/summary.md\n"
-        env = {
-            "SUMMARIZE_COMMIT_SHA": FAKE_COMMIT_SHA,
-            "SUMMARIZE_COMMIT_FOUND": "true",
-            "PRIVATE_EMAIL": "private@example.com",
-            "DIGEST_TO": "user@example.com",
-            "OPENAI_API_KEY": "",
-            "RESEND_API_KEY": "key",
-        }
-        with (
-            patch("send_digest.subprocess.run", return_value=_mock_subprocess_result(diff_output)),
-            patch("send_digest.os.environ.get", side_effect=lambda k, d="": env.get(k, d)),
-            patch("send_digest._is_trivial_transcript", return_value=False),
-            pytest.raises(SystemExit) as exc_info,
-        ):
-            main()
-        assert exc_info.value.code == 1
-
     def test_all_trivial_summaries_skips(self) -> None:
         """All summaries trivial → exits cleanly with no email sent."""
         diff_output = "docs/content/Go-SIG/2026-03-05/summary.md\n"

--- a/tests/test_send_digest.py
+++ b/tests/test_send_digest.py
@@ -458,6 +458,18 @@ class TestBuildEmail:
         assert lines[1] == ""
         assert lines[2] == "---"
 
+    def test_text_body_uses_highlights_not_full_content(self) -> None:
+        """Plain-text body should contain key-topic highlights, not full summary content."""
+        summaries = [{"slug": "Go-SIG", "date": "2026-03-05", "content": SAMPLE_SUMMARY}]
+        with patch("send_digest._render_html", return_value="<html>mock</html>"):
+            email = build_email(summaries, "2026-03-05", 1)
+        text = email["text"]
+        # Key topic should be present
+        assert "Discussed collector stability" in text
+        # Action items and participants should NOT be in the text body
+        assert "Follow up on PR #123" not in text
+        assert "Tyler, Damien" not in text
+
 
 # ---------------------------------------------------------------------------
 # TestParseSummaryInfo — filesystem path (no commit SHA)


### PR DESCRIPTION
- Remove OpenAI narrative generation from send_digest.py (all narrative functions, constants, imports, and OPENAI_API_KEY dependency)
- Remove 'Today across OTel' callout box from digest_template.html
- Remove OPENAI_API_KEY from digest workflow env vars
- Update tests to remove all OpenAI/narrative test cases and add verification that narrative is absent from template vars and text body